### PR TITLE
Add support for IoVec functions read_bufs/write_bufs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["asynchronous"]
 travis-ci = { repository = "alexcrichton/mio-uds" }
 
 [target."cfg(unix)".dependencies]
+iovec = "0.1"
 libc = "0.2"
 mio = "0.6.5"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/mio-uds/0.6")]
 
+extern crate iovec;
 extern crate libc;
 extern crate mio;
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,3 +1,4 @@
+extern crate iovec;
 extern crate mio;
 extern crate tempdir;
 extern crate mio_uds;
@@ -5,6 +6,7 @@ extern crate mio_uds;
 use std::io::prelude::*;
 use std::time::Duration;
 
+use iovec::IoVec;
 use mio::*;
 use mio_uds::*;
 use tempdir::TempDir;
@@ -63,4 +65,37 @@ fn stream() {
     assert_eq!(events.get(0).unwrap().token(), Token(2));
 
     assert_eq!(t!(b.read(&mut [0; 1024])), 1);
+}
+
+#[test]
+fn stream_iovec() {
+    let poll = t!(Poll::new());
+    let mut events = Events::with_capacity(1024);
+    let (a, b) = t!(UnixStream::pair());
+
+    let both = Ready::readable() | Ready::writable();
+    t!(poll.register(&a, Token(1), both, PollOpt::edge()));
+    t!(poll.register(&b, Token(2), both, PollOpt::edge()));
+
+    assert_eq!(t!(poll.poll(&mut events, Some(Duration::new(0, 0)))), 2);
+    assert_eq!(events.get(0).unwrap().readiness(), Ready::writable());
+    assert_eq!(events.get(1).unwrap().readiness(), Ready::writable());
+
+    let send = b"Hello, World!";
+    let vecs: [&IoVec;2] = [ (&send[..6]).into(),
+                             (&send[6..]).into() ];
+
+    assert_eq!(t!(a.write_bufs(&vecs)), send.len());
+
+    assert_eq!(t!(poll.poll(&mut events, Some(Duration::new(0, 0)))), 1);
+    assert!(events.get(0).unwrap().readiness().is_readable());
+    assert_eq!(events.get(0).unwrap().token(), Token(2));
+
+    let mut recv = [0; 13];
+    {
+        let (mut first, mut last) = recv.split_at_mut(6);
+        let mut vecs: [&mut IoVec;2] = [ first.into(), last.into() ];
+        assert_eq!(t!(b.read_bufs(&mut vecs)), send.len());
+    }
+    assert_eq!(&send[..], &recv[..]);
 }


### PR DESCRIPTION
I've been working on implementing an RPC system built on top of Unix Domain Sockets with support for fd passing. This patch adds support for read_bufs/write_bufs to bring the functionality inline with TcpStream in the mio crate.

The current implementation for is using libc::{readv, writev}, but in a follow up I plan to switch to using libc::{recvmsg, sendmsg} when support for fd passing is added.