### PR TITLE
Fix for Android aarch64 socket type

### DIFF
--- a/src/datagram.rs
+++ b/src/datagram.rs
@@ -24,7 +24,7 @@ impl UnixDatagram {
         UnixDatagram::_bind(path.as_ref())
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
     fn _bind(path: &Path) -> io::Result<UnixDatagram> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));
@@ -37,7 +37,7 @@ impl UnixDatagram {
         }
     }
     
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64",target_os = "android"))]
     fn _bind(path: &Path) -> io::Result<UnixDatagram> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));

--- a/src/datagram.rs
+++ b/src/datagram.rs
@@ -10,6 +10,7 @@ use mio::unix::EventedFd;
 use mio::{Poll, Token, Ready, PollOpt};
 
 use cvt;
+use Len;
 use socket::{sockaddr_un, Socket};
 
 /// A Unix datagram socket.
@@ -24,27 +25,13 @@ impl UnixDatagram {
         UnixDatagram::_bind(path.as_ref())
     }
 
-    #[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
     fn _bind(path: &Path) -> io::Result<UnixDatagram> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));
             let fd = try!(Socket::new(libc::SOCK_DGRAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len)));
-
-            Ok(UnixDatagram::from_raw_fd(fd.into_fd()))
-        }
-    }
-    
-    #[cfg(all(target_arch = "aarch64",target_os = "android"))]
-    fn _bind(path: &Path) -> io::Result<UnixDatagram> {
-        unsafe {
-            let (addr, len) = try!(sockaddr_un(path));
-            let fd = try!(Socket::new(libc::SOCK_DGRAM));
-
-            let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as i32)));
+            try!(cvt(libc::bind(fd.fd(), addr, len as Len)));
 
             Ok(UnixDatagram::from_raw_fd(fd.into_fd()))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,11 @@ pub use stream::UnixStream;
 pub use listener::UnixListener;
 pub use datagram::UnixDatagram;
 
+#[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
+type Len = u32;
+#[cfg(all(target_arch = "aarch64",target_os = "android"))]
+type Len = i32;
+
 fn cvt(i: libc::c_int) -> io::Result<libc::c_int> {
     if i == -1 {
         Err(io::Error::last_os_error())

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -10,6 +10,7 @@ use mio::{Poll, Token, Ready, PollOpt};
 
 use UnixStream;
 use cvt;
+use Len;
 use socket::{sockaddr_un, Socket};
 
 /// A structure representing a Unix domain socket server.
@@ -28,28 +29,13 @@ impl UnixListener {
         UnixListener::_bind(path.as_ref())
     }
 
-    #[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
     fn _bind(path: &Path) -> io::Result<UnixListener> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));
             let fd = try!(Socket::new(libc::SOCK_STREAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len)));
-            try!(cvt(libc::listen(fd.fd(), 128)));
-
-            Ok(UnixListener::from_raw_fd(fd.into_fd()))
-        }
-    }
-
-    #[cfg(all(target_arch = "aarch64",target_os = "android"))]
-    fn _bind(path: &Path) -> io::Result<UnixListener> {
-        unsafe {
-            let (addr, len) = try!(sockaddr_un(path));
-            let fd = try!(Socket::new(libc::SOCK_STREAM));
-
-            let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as i32)));
+            try!(cvt(libc::bind(fd.fd(), addr, len as Len)));
             try!(cvt(libc::listen(fd.fd(), 128)));
 
             Ok(UnixListener::from_raw_fd(fd.into_fd()))

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -28,7 +28,7 @@ impl UnixListener {
         UnixListener::_bind(path.as_ref())
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
     fn _bind(path: &Path) -> io::Result<UnixListener> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));
@@ -42,7 +42,7 @@ impl UnixListener {
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64",target_os = "android"))]
     fn _bind(path: &Path) -> io::Result<UnixListener> {
         unsafe {
             let (addr, len) = try!(sockaddr_un(path));


### PR DESCRIPTION
I separated both functions and cast the u32 to i32 in the bind call.

This is similar to how mio handled the same problem.