### PR TITLE
libc 0.2.42 changed definition of bind to use socklen_t on aarch64-linux-android 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "alexcrichton/mio-uds" }
 
 [target."cfg(unix)".dependencies]
 iovec = "0.1"
-libc = "0.2"
+libc = "0.2.42"
 mio = "0.6.5"
 
 [dev-dependencies]

--- a/src/datagram.rs
+++ b/src/datagram.rs
@@ -10,7 +10,6 @@ use mio::unix::EventedFd;
 use mio::{Poll, Token, Ready, PollOpt};
 
 use cvt;
-use Len;
 use socket::{sockaddr_un, Socket};
 
 /// A Unix datagram socket.
@@ -31,7 +30,7 @@ impl UnixDatagram {
             let fd = try!(Socket::new(libc::SOCK_DGRAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as Len)));
+            try!(cvt(libc::bind(fd.fd(), addr, len as libc::socklen_t)));
 
             Ok(UnixDatagram::from_raw_fd(fd.into_fd()))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,6 @@ pub use stream::UnixStream;
 pub use listener::UnixListener;
 pub use datagram::UnixDatagram;
 
-#[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
-type Len = libc::socklen_t;
-// Match Android weirdness for aarch64 found in libc.
-#[cfg(all(target_arch = "aarch64",target_os = "android"))]
-type Len = libc::c_int;
-
 fn cvt(i: libc::c_int) -> io::Result<libc::c_int> {
     if i == -1 {
         Err(io::Error::last_os_error())

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -10,7 +10,6 @@ use mio::{Poll, PollOpt, Ready, Token};
 
 use UnixStream;
 use cvt;
-use Len;
 use socket::{sockaddr_un, Socket};
 
 /// A structure representing a Unix domain socket server.
@@ -35,7 +34,7 @@ impl UnixListener {
             let fd = try!(Socket::new(libc::SOCK_STREAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as Len)));
+            try!(cvt(libc::bind(fd.fd(), addr, len as libc::socklen_t)));
             try!(cvt(libc::listen(fd.fd(), 128)));
 
             Ok(UnixListener::from_raw_fd(fd.into_fd()))


### PR DESCRIPTION
See also carllerche/mio#846 for compiling `mio-uds` under aarch64 android 