### PR TITLE
Attempting to fix socket type on all platforms

### DIFF
--- a/src/datagram.rs
+++ b/src/datagram.rs
@@ -30,7 +30,7 @@ impl UnixDatagram {
             let fd = try!(Socket::new(libc::SOCK_DGRAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as libc::socklen_t)));
+            try!(cvt(libc::bind(fd.fd(), addr, len)));
 
             Ok(UnixDatagram::from_raw_fd(fd.into_fd()))
         }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -34,7 +34,7 @@ impl UnixListener {
             let fd = try!(Socket::new(libc::SOCK_STREAM));
 
             let addr = &addr as *const _ as *const _;
-            try!(cvt(libc::bind(fd.fd(), addr, len as libc::socklen_t)));
+            try!(cvt(libc::bind(fd.fd(), addr, len)));
             try!(cvt(libc::listen(fd.fd(), 128)));
 
             Ok(UnixListener::from_raw_fd(fd.into_fd()))


### PR DESCRIPTION
So it seems that the problem has returned.

As far as I know, the only problem was the type cast, this has been removed. 

Working Platforms:
  - [X] ~~```x86_64-unknown-linux-gnu```~~
  - [X] ~~```aarch64-linux-android```~~
  - [x] ~~```armv7-linux-androideabi```~~
  - [x] ~~```i686-linux-android```~~

More platforms will be added as I get word on their status.