### PR TITLE
Add cargo fmt check and format code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ matrix:
       after_success:
         - travis-cargo --only nightly doc-upload
 
+before_script:
+  - rustup component add rustfmt
+
 script:
+  - cargo fmt -- --check
   - cargo test
 
 env:

--- a/src/datagram.rs
+++ b/src/datagram.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use libc;
 use mio::event::Evented;
 use mio::unix::EventedFd;
-use mio::{Poll, Token, Ready, PollOpt};
+use mio::{Poll, PollOpt, Ready, Token};
 
 use cvt;
 use socket::{sockaddr_un, Socket};
@@ -52,8 +52,10 @@ impl UnixDatagram {
     pub fn pair() -> io::Result<(UnixDatagram, UnixDatagram)> {
         unsafe {
             let (a, b) = try!(Socket::pair(libc::SOCK_DGRAM));
-            Ok((UnixDatagram::from_raw_fd(a.into_fd()),
-                UnixDatagram::from_raw_fd(b.into_fd())))
+            Ok((
+                UnixDatagram::from_raw_fd(a.into_fd()),
+                UnixDatagram::from_raw_fd(b.into_fd()),
+            ))
         }
     }
 
@@ -78,9 +80,7 @@ impl UnixDatagram {
     /// object references. Both handles can be used to accept incoming
     /// connections and options set on one listener will affect the other.
     pub fn try_clone(&self) -> io::Result<UnixDatagram> {
-        self.inner.try_clone().map(|i| {
-            UnixDatagram { inner: i }
-        })
+        self.inner.try_clone().map(|i| UnixDatagram { inner: i })
     }
 
     /// Returns the address of this socket.
@@ -143,19 +143,17 @@ impl UnixDatagram {
 }
 
 impl Evented for UnixDatagram {
-    fn register(&self,
-                poll: &Poll,
-                token: Token,
-                events: Ready,
-                opts: PollOpt) -> io::Result<()> {
+    fn register(&self, poll: &Poll, token: Token, events: Ready, opts: PollOpt) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).register(poll, token, events, opts)
     }
 
-    fn reregister(&self,
-                  poll: &Poll,
-                  token: Token,
-                  events: Ready,
-                  opts: PollOpt) -> io::Result<()> {
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        events: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).reregister(poll, token, events, opts)
     }
 
@@ -178,6 +176,8 @@ impl IntoRawFd for UnixDatagram {
 
 impl FromRawFd for UnixDatagram {
     unsafe fn from_raw_fd(fd: i32) -> UnixDatagram {
-        UnixDatagram { inner: net::UnixDatagram::from_raw_fd(fd) }
+        UnixDatagram {
+            inner: net::UnixDatagram::from_raw_fd(fd),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ mod listener;
 mod socket;
 mod stream;
 
-pub use stream::UnixStream;
-pub use listener::UnixListener;
 pub use datagram::UnixDatagram;
+pub use listener::UnixListener;
+pub use stream::UnixStream;
 
 fn cvt(i: libc::c_int) -> io::Result<libc::c_int> {
     if i == -1 {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -8,9 +8,9 @@ use mio::event::Evented;
 use mio::unix::EventedFd;
 use mio::{Poll, PollOpt, Ready, Token};
 
-use UnixStream;
 use cvt;
 use socket::{sockaddr_un, Socket};
+use UnixStream;
 
 /// A structure representing a Unix domain socket server.
 ///

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,7 @@
 extern crate iovec;
 extern crate mio;
-extern crate tempdir;
 extern crate mio_uds;
+extern crate tempdir;
 
 use std::io::prelude::*;
 use std::time::Duration;
@@ -12,10 +12,12 @@ use mio_uds::*;
 use tempdir::TempDir;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
@@ -39,8 +41,14 @@ fn listener() {
 
     let (s2, addr) = t!(a.accept()).unwrap();
 
-    assert_eq!(t!(s.peer_addr()).as_pathname(), t!(s2.local_addr()).as_pathname());
-    assert_eq!(t!(s.local_addr()).as_pathname(), t!(s2.peer_addr()).as_pathname());
+    assert_eq!(
+        t!(s.peer_addr()).as_pathname(),
+        t!(s2.local_addr()).as_pathname()
+    );
+    assert_eq!(
+        t!(s.local_addr()).as_pathname(),
+        t!(s2.peer_addr()).as_pathname()
+    );
     assert_eq!(addr.as_pathname(), t!(s.local_addr()).as_pathname());
 }
 
@@ -82,8 +90,7 @@ fn stream_iovec() {
     assert_eq!(events.get(1).unwrap().readiness(), Ready::writable());
 
     let send = b"Hello, World!";
-    let vecs: [&IoVec;2] = [ (&send[..6]).into(),
-                             (&send[6..]).into() ];
+    let vecs: [&IoVec; 2] = [(&send[..6]).into(), (&send[6..]).into()];
 
     assert_eq!(t!(a.write_bufs(&vecs)), send.len());
 
@@ -94,7 +101,7 @@ fn stream_iovec() {
     let mut recv = [0; 13];
     {
         let (mut first, mut last) = recv.split_at_mut(6);
-        let mut vecs: [&mut IoVec;2] = [ first.into(), last.into() ];
+        let mut vecs: [&mut IoVec; 2] = [first.into(), last.into()];
         assert_eq!(t!(b.read_bufs(&mut vecs)), send.len());
     }
     assert_eq!(&send[..], &recv[..]);


### PR DESCRIPTION
Intended to aid future changes such as addressing some existing
compilation warnings, etc.  This crate is used by tokio-net
with the uds feature.