### PR TITLE
illumos/solaris should use SOCK_CLOEXEC|SOCK_NONBLOCK

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -15,9 +15,23 @@ use cvt;
 // actually ever used (the blocks below are wrapped in `if cfg!` as well.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::{SOCK_CLOEXEC, SOCK_NONBLOCK};
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+const SOCK_CLOEXEC: c_int = 0x080000;
+#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+const SOCK_NONBLOCK: c_int = 0x100000;
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris"
+)))]
 const SOCK_CLOEXEC: c_int = 0;
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris"
+)))]
 const SOCK_NONBLOCK: c_int = 0;
 
 pub struct Socket {
@@ -32,7 +46,11 @@ impl Socket {
             // this option, however, was added in 2.6.27, and we still support
             // 2.6.18 as a kernel, so if the returned error is EINVAL we
             // fallthrough to the fallback.
-            if cfg!(target_os = "linux") || cfg!(target_os = "android") {
+            if cfg!(target_os = "linux")
+                || cfg!(target_os = "android")
+                || cfg!(target_os = "illumos")
+                || cfg!(target_os = "solaris")
+            {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socket(libc::AF_UNIX, flags, 0)) {
                     Ok(fd) => return Ok(Socket { fd: fd }),
@@ -54,7 +72,11 @@ impl Socket {
             let mut fds = [0, 0];
 
             // Like above, see if we can set cloexec atomically
-            if cfg!(target_os = "linux") || cfg!(target_os = "android") {
+            if cfg!(target_os = "linux")
+                || cfg!(target_os = "android")
+                || cfg!(target_os = "illumos")
+                || cfg!(target_os = "solaris")
+            {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr())) {
                     Ok(_) => {


### PR DESCRIPTION
Found this was broken on illumos while working on a tokio issue.
Calling the following on illumos will result in EINVAL -- `try!(cvt(libc::ioctl(fd.fd, libc::FIOCLEX)));`

We support `SOCK_CLOEXEC` and `SOCK_NONBLOCK`, although it looks like those currently are not in the libc crate, so I will open a PR there as well to get those added.

That means we can merge this or wait for the libc changes to get merged and bump the libc dependency in this crate.  Either works for me.