### PR TITLE
Send and receive FDs

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -188,7 +188,7 @@ impl UnixStream {
     /// if successful, or an error is returned otherwise. If no bytes are
     /// available to be read yet then a "would block" error is returned.
     /// This operation does not block.
-    pub fn read_bufs_fds(&mut self, bufs: &mut [&mut IoVec])
+    pub fn read_bufs_fds(&self, bufs: &mut [&mut IoVec])
         -> io::Result<(usize, Vec<RawFd>)> {
         unsafe {
             let iov = iovec::as_os_slice_mut(bufs);
@@ -254,7 +254,7 @@ impl UnixStream {
     /// The number of bytes written is returned, if successful, or an error is
     /// returned otherwise. If the socket is not currently writable then a
     /// "would block" error is returned. This operation does not block.
-    pub fn write_bufs_fds(&mut self, bufs: &mut [&mut IoVec], fds: &[RawFd])
+    pub fn write_bufs_fds(&self, bufs: &mut [&mut IoVec], fds: &[RawFd])
         -> io::Result<usize> {
         unsafe {
             let iov = iovec::as_os_slice_mut(bufs);


### PR DESCRIPTION
I added two functions `read_bufs_fds()` and `write_bufs_fds()` to send and receive file descriptor over Unix domain socket. It uses the `sendmsg()` and `recvmsg()` system call. I plan to add this feature to the tokio framework, in the future.