### PR TITLE
Add support for illumos target

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -13,11 +13,26 @@ use cvt;
 // get name resolution to work and things to compile we just define a dummy
 // SOCK_CLOEXEC here for other platforms. Note that the dummy constant isn't
 // actually ever used (the blocks below are wrapped in `if cfg!` as well.
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "illumos"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris"
+))]
 use libc::{SOCK_CLOEXEC, SOCK_NONBLOCK};
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "illumos")))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris"
+)))]
 const SOCK_CLOEXEC: c_int = 0;
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "illumos")))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris"
+)))]
 const SOCK_NONBLOCK: c_int = 0;
 
 pub struct Socket {
@@ -32,7 +47,12 @@ impl Socket {
             // this option, however, was added in 2.6.27, and we still support
             // 2.6.18 as a kernel, so if the returned error is EINVAL we
             // fallthrough to the fallback.
-            if cfg!(any(target_os = "linux", target_os = "android", target_os = "illumos")) {
+            if cfg!(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "illumos",
+                target_os = "solaris"
+            )) {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socket(libc::AF_UNIX, flags, 0)) {
                     Ok(fd) => return Ok(Socket { fd: fd }),
@@ -54,7 +74,12 @@ impl Socket {
             let mut fds = [0, 0];
 
             // Like above, see if we can set cloexec atomically
-            if cfg!(any(target_os = "linux", target_os = "android", target_os = "illumos")) {
+            if cfg!(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "illumos",
+                target_os = "solaris"
+            )) {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr())) {
                     Ok(_) => {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -13,11 +13,11 @@ use cvt;
 // get name resolution to work and things to compile we just define a dummy
 // SOCK_CLOEXEC here for other platforms. Note that the dummy constant isn't
 // actually ever used (the blocks below are wrapped in `if cfg!` as well.
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "illumos"))]
 use libc::{SOCK_CLOEXEC, SOCK_NONBLOCK};
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "illumos")))]
 const SOCK_CLOEXEC: c_int = 0;
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "illumos")))]
 const SOCK_NONBLOCK: c_int = 0;
 
 pub struct Socket {
@@ -32,7 +32,7 @@ impl Socket {
             // this option, however, was added in 2.6.27, and we still support
             // 2.6.18 as a kernel, so if the returned error is EINVAL we
             // fallthrough to the fallback.
-            if cfg!(target_os = "linux") || cfg!(target_os = "android") {
+            if cfg!(any(target_os = "linux", target_os = "android", target_os = "illumos")) {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socket(libc::AF_UNIX, flags, 0)) {
                     Ok(fd) => return Ok(Socket { fd: fd }),
@@ -54,7 +54,7 @@ impl Socket {
             let mut fds = [0, 0];
 
             // Like above, see if we can set cloexec atomically
-            if cfg!(target_os = "linux") || cfg!(target_os = "android") {
+            if cfg!(any(target_os = "linux", target_os = "android", target_os = "illumos")) {
                 let flags = ty | SOCK_CLOEXEC | SOCK_NONBLOCK;
                 match cvt(libc::socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr())) {
                     Ok(_) => {


### PR DESCRIPTION
Like Linux and Android, illumos supports the SOCK_CLOEXEC and
SOCK_NONBLOCK flags, while being less forgiving of FIOCLEX usage against
AF_UNIX sockets.